### PR TITLE
Format the response body into a readable JSON object

### DIFF
--- a/src/management/v2/index.ts
+++ b/src/management/v2/index.ts
@@ -127,7 +127,7 @@ export class Client {
 
   private checkResponseStatus(requestLine: string, response: Response): void {
     if (response.status > 299) {
-      throw new Error(`ERROR DURING ${requestLine}: ${response.status} - ${response.body}`);
+      throw new Error(`ERROR DURING ${requestLine}: ${response.status} - ${JSON.stringify(response.body)}`);
     }
   }
 }

--- a/src/management/v3/index.ts
+++ b/src/management/v3/index.ts
@@ -147,7 +147,7 @@ export class Client {
 
   private checkResponseStatus(requestLine: string, response: Response): void {
     if (response.status > 299) {
-      throw new Error(`ERROR DURING ${requestLine}: ${response.status} - ${response.body}`);
+      throw new Error(`ERROR DURING ${requestLine}: ${response.status} - ${JSON.stringify(response.body)}`);
     }
   }
 }


### PR DESCRIPTION
Without this change the output just reads `[object Object]`:

```
app:index Error: Error: ERROR DURING POST /content/scripts: 422 - [object Object] at Client.checkResponseStatus
```