### PR TITLE
Add the ability to specify custom BC endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "rimraf": "^3.0.2",
         "shell-escape": "^0.2.0",
         "temp-dir": "^2.0.0",
-        "typescript": "^4.3.5",
+        "typescript": "^4.4.2",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -1044,9 +1044,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1887,9 +1887,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rimraf": "^3.0.2",
     "shell-escape": "^0.2.0",
     "temp-dir": "^2.0.0",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.2",
     "uuid": "^8.3.2"
   },
   "dependencies": {

--- a/src/internal/type-utils.ts
+++ b/src/internal/type-utils.ts
@@ -8,3 +8,6 @@ type Narrowable =
   | bigint
   | boolean
   | readonly any[];
+
+export type RemoveStart<Start extends string, Subject extends string> =
+  Subject extends `${Start}${infer End}` ? End : never

--- a/src/management/index.ts
+++ b/src/management/index.ts
@@ -11,11 +11,36 @@ export type Config = {
   readonly agent?: Agent
 };
 
-export class Client {
+/**
+ * If you need to use a path which is not part if the spec, you can pass it
+ * into the client via a type parameter to avoid TypeScript errors, e.g.:
+ *  
+ *   type MyExtraEndpoints = 
+ *     | 'GET /v3/foo/bar'
+ *     | 'POST /v3/foo/bar'
+ *     | 'GET /v2/foo/baz'
+ *   ;
+ * 
+ *   bigCommerce = new Client<MyExtraEndpoints>(config)
+ */
+
+export class Client<CustomEndpoints extends string = never> {
   constructor(
     private readonly config: Config
   ) {}
 
-  readonly v2 = new V2.Client(this.config);
-  readonly v3 = new V3.Client(this.config);
+  readonly v2 = new V2.Client<ExtractSubpaths<'/v2', CustomEndpoints>>(this.config);
+  readonly v3 = new V3.Client<ExtractSubpaths<'/v3', CustomEndpoints>>(this.config);
 }
+
+export namespace Client {
+  export type AdditonalPaths = {
+    V2?: AdditonalPaths
+  }
+}
+
+type ExtractSubpaths<Path extends string, AllCustomEndpoints extends string>
+  = AllCustomEndpoints extends `${infer Method} ${Path}${infer Subpath}`
+    ? `${Method} ${Subpath}`
+    : never
+;

--- a/src/management/v2/index.ts
+++ b/src/management/v2/index.ts
@@ -26,7 +26,7 @@ export type Config = Omit<FetchTransportOptions, 'baseUrl' | 'headers'> & {
   readonly accessToken: string
 };
 
-export class Client {
+export class Client<CustomEndpoints extends string = never> {
   constructor(config: Config)
 
   constructor(transport: Transport)

--- a/src/management/v2/index.ts
+++ b/src/management/v2/index.ts
@@ -51,7 +51,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[ReqLine]>>
   ): Promise<InferResponse<ReqLine, Params>>
 
-  send(requestLine: UntypedEndpoints | CustomEndpoints, params?: Parameters): Promise<Response>
+  send(requestLine: string, params?: Parameters): Promise<Response>
 
   async send(requestLine: string, params?: Parameters): Promise<Response> {
     return this.transport(requestLine, params);

--- a/src/management/v2/index.ts
+++ b/src/management/v2/index.ts
@@ -1,7 +1,7 @@
 import type { V2 as reference } from "../../internal/reference";
 import type { NarrowResponse } from "./response-narrowing"
 import { Operation, OperationIndex, Parameters, Request, RequestMethod, Response, fetchTransport, Transport, FetchTransportOptions } from "../../internal/operation";
-import { Const } from "../../internal/type-utils";
+import { Const, RemoveStart } from "../../internal/type-utils";
 
 export type Operations = reference.Operation;
 
@@ -51,7 +51,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[ReqLine]>>
   ): Promise<InferResponse<ReqLine, Params>>
 
-  send(requestLine: string, params?: Parameters): Promise<Response>
+  send(requestLine: UntypedEndpoints | CustomEndpoints, params?: Parameters): Promise<Response>
 
   async send(requestLine: string, params?: Parameters): Promise<Response> {
     return this.transport(requestLine, params);
@@ -64,7 +64,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[`DELETE ${Path}`]>>
   ): Promise<ResponseData<`DELETE ${Path}`, Params> | null>
 
-  delete<T = unknown>(path: string, params?: Parameters): Promise<T>
+  delete<T = unknown>(path: RemoveStart<'DELETE ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async delete(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`DELETE ${path}`, params);
@@ -82,7 +82,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[`GET ${Path}`]>>
   ): Promise<ResponseData<`GET ${Path}`, Params> | null>
 
-  get<T = unknown>(path: string, params?: Parameters): Promise<T>
+  get<T = unknown>(path: RemoveStart<'GET ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async get(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`GET ${path}`, params);
@@ -100,7 +100,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[`POST ${Path}`]>>
   ): Promise<ResponseData<`POST ${Path}`, Params>>
 
-  post<T = unknown>(path: string, params?: Parameters): Promise<T>
+  post<T = unknown>(path: RemoveStart<'POST ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async post(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`POST ${path}`, params);
@@ -115,7 +115,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[`PUT ${Path}`]>>
   ): Promise<ResponseData<`PUT ${Path}`, Params>>
 
-  put<T = unknown>(path: string, params?: Parameters): Promise<T>
+  put<T = unknown>(path: RemoveStart<'PUT ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async put(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`PUT ${path}`, params);
@@ -142,3 +142,10 @@ type RequestPath<Method extends RequestMethod> =
 
 type NoParamsRequestPath<Method extends RequestMethod> =
   NoParamsRequestLine & `${Method} ${any}` extends `${Method} ${infer Path}` ? Path : never;
+
+/**
+ * A list of known BigCommerce endpoints which are not part of the Open API specs
+ */
+type UntypedEndpoints =
+ | never
+;

--- a/src/management/v3/index.ts
+++ b/src/management/v3/index.ts
@@ -187,4 +187,23 @@ type NoParamsRequestPath<Method extends RequestMethod> =
 /**
  * A list of known BigCommerce endpoints which are not part of the Open API specs
  */
-type UntypedEndpoints = never;
+type UntypedEndpoints =
+  | PromoEndpoints
+  | PromoCodeEndpoints
+;
+
+type PromoEndpoints = 
+  | 'GET /promotions'
+  | 'GET /promotions/{id}'
+  | 'POST /promotions'
+  | 'PUT /promotions/{id}'
+  | 'DELETE /promotions'
+  | 'DELETE /promotions/{id}'
+;
+
+type PromoCodeEndpoints = 
+  | 'GET /promotions/{promotion_id}/codes'
+  | 'POST /promotions/{promotion_id}/codes'
+  | 'DELETE /promotions/{promotion_id}/codes'
+  | 'DELETE /promotions/{promotion_id}/codes/{code_id}'
+;

--- a/src/management/v3/index.ts
+++ b/src/management/v3/index.ts
@@ -2,6 +2,7 @@ import type { V3 as reference } from "../../internal/reference";
 import type { NarrowResponse } from "./response-narrowing"
 import { Operation, OperationIndex, Parameters, Request, RequestMethod, Response, fetchTransport, Transport, FetchTransportOptions } from "../../internal/operation";
 import { Const } from "../../internal/type-utils";
+import { RemoveStart } from "../../internal/type-utils";
 
 export type Operations = reference.Operation;
 
@@ -25,8 +26,8 @@ export type Config = Omit<FetchTransportOptions, 'baseUrl' | 'headers'> & {
   readonly storeHash: string
   readonly accessToken: string
 };
-    
-export class Client {
+
+export class Client<CustomEndpoints extends string = never> {
   constructor(config: Config)
 
   constructor(transport: Transport)
@@ -51,7 +52,7 @@ export class Client {
     params: Const<Params & Operation.MinimalInput<Operations[ReqLine]>>
   ): Promise<InferResponse<ReqLine, Params>>
 
-  send(requestLine: string, params?: Parameters): Promise<Response>
+  send(requestLine: CustomEndpoints, params?: Parameters): Promise<Response>
 
   send(requestLine: string, params?: Parameters): Promise<Response> {
     return this.transport(requestLine, params);
@@ -64,7 +65,7 @@ export class Client {
     params: Const<Params & Operation.MinimalInput<Operations[`GET ${Path}`]>>
   ): Promise<ResponseData<`GET ${Path}`, Params> | null>
 
-  get<T = unknown>(path: string, params?: Parameters): Promise<T>
+  get<T = unknown>(path: RemoveStart<'GET ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async get(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`GET ${path}`, params);
@@ -82,7 +83,7 @@ export class Client {
     params: Const<Params & Operation.MinimalInput<Operations[`GET ${Path}`]>>
   ): AsyncIterable<ListItemType<Path, Params>>
 
-  list<T = unknown>(path: string, params?: Parameters): AsyncIterable<T>
+  list<T = unknown>(path: RemoveStart<'GET ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): AsyncIterable<T>
 
   async *list<T>(path: string, params?: Parameters): AsyncIterable<T> {
     const MAX_PAGES = Number.MAX_SAFE_INTEGER;
@@ -104,7 +105,7 @@ export class Client {
     params: Const<Params & Operation.MinimalInput<Operations[`POST ${Path}`]>>
   ): Promise<ResponseData<`POST ${Path}`, Params>>
 
-  post<T = unknown>(path: string, params?: Parameters): Promise<T>
+  post<T = unknown>(path: RemoveStart<'POST ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async post(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`POST ${path}`, params);
@@ -119,7 +120,7 @@ export class Client {
     params: Const<Params & Operation.MinimalInput<Operations[`PUT ${Path}`]>>
   ): Promise<ResponseData<`PUT ${Path}`, Params>>
 
-  put<T = unknown>(path: string, params?: Parameters): Promise<T>
+  put<T = unknown>(path: RemoveStart<'PUT ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async put(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`PUT ${path}`, params);
@@ -134,7 +135,7 @@ export class Client {
     params: Const<Params & Operation.MinimalInput<Operations[`DELETE ${Path}`]>>
   ): Promise<ResponseData<`DELETE ${Path}`, Params> | null>
 
-  delete<T = unknown>(path: string, params?: Parameters): Promise<T>
+  delete<T = unknown>(path: RemoveStart<'DELETE ', UntypedEndpoints | CustomEndpoints>, params?: Parameters): Promise<T>
 
   async delete(path: string, params?: Parameters): Promise<unknown> {
     const res = await this.send(`DELETE ${path}`, params);
@@ -182,3 +183,8 @@ type RequestPath<Method extends RequestMethod> =
 
 type NoParamsRequestPath<Method extends RequestMethod> =
   NoParamsRequestLine & `${Method} ${any}` extends `${Method} ${infer Path}` ? Path : never;
+
+/**
+ * A list of known BigCommerce endpoints which are not part of the Open API specs
+ */
+type UntypedEndpoints = never;

--- a/src/management/v3/index.ts
+++ b/src/management/v3/index.ts
@@ -52,7 +52,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[ReqLine]>>
   ): Promise<InferResponse<ReqLine, Params>>
 
-  send(requestLine: UntypedEndpoints | CustomEndpoints, params?: Parameters): Promise<Response>
+  send(requestLine: string, params?: Parameters): Promise<Response>
 
   send(requestLine: string, params?: Parameters): Promise<Response> {
     return this.transport(requestLine, params);

--- a/src/management/v3/index.ts
+++ b/src/management/v3/index.ts
@@ -52,7 +52,7 @@ export class Client<CustomEndpoints extends string = never> {
     params: Const<Params & Operation.MinimalInput<Operations[ReqLine]>>
   ): Promise<InferResponse<ReqLine, Params>>
 
-  send(requestLine: CustomEndpoints, params?: Parameters): Promise<Response>
+  send(requestLine: UntypedEndpoints | CustomEndpoints, params?: Parameters): Promise<Response>
 
   send(requestLine: string, params?: Parameters): Promise<Response> {
     return this.transport(requestLine, params);


### PR DESCRIPTION
This PR adds the ability to specify custom endpoints which do not have types defined in the API specs.

It also adds endpoints for `/v3/promotions` (in beta at time of writing).